### PR TITLE
README: reference prebuilt binaries

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,9 @@
 Customised live version of Arch Linux with pre-installed packages for Nouveau
 
-!!! Currently only work for x86_64 architectures !!!
+Prebuilt images are hosted on https://nouveau.pmoreau.org -- the build process
+for these is currently broken, so they are not being updated regularly.
+
+!!! Currently only works for x86_64 architectures !!!
 
 Pre-installed kernels:
 1) Nouveau (git://people.freedesktop.org/~darktama/nouveau)


### PR DESCRIPTION
This github repository sufficiently highly ranked for [`nouveau arch linux mesa-git`](https://www.google.com/search?q=nouveau+arch+linux+mesa-git), but https://nouveau.pmoreau.org is not.

Reference it in README to improve (re)discovery.